### PR TITLE
Added API endpoint POST /artifacts

### DIFF
--- a/backend/Artifacts/Artifacts.py
+++ b/backend/Artifacts/Artifacts.py
@@ -1,0 +1,163 @@
+import hashlib
+import json
+import os
+import boto3
+
+
+def lambda_handler(event, context):
+  """AWS Lambda handler to list artifact metadata stored in S3.
+
+  The handler expects an event with an optional JSON body containing:
+    - name: str (currently unused; kept for compatibility)
+    - types: List[str]
+
+  Pagination is controlled by an "offset" header.
+  """
+  s3_bucket = os.environ.get("REGISTRY_BUCKET")
+  if not s3_bucket:
+    print("lambda_handler: REGISTRY_BUCKET not configured")
+    return {
+      "statusCode": 500,
+      "body": json.dumps({"error": "REGISTRY_BUCKET not configured"}),
+    }
+
+  # Sanitize request
+  sanitized, error_response = sanitize_request(event)
+  if error_response:
+    print(f"Bad Sanitize = {error_response}")
+    return error_response
+
+  # name is kept for compatibility but not used to filter results here
+  name = sanitized["name"]
+  types = sanitized["types"]
+
+  # Handle pagination offset
+  try:
+    offset = int(event.get("headers", {}).get("offset", 0))
+  except (TypeError, ValueError):
+    offset = 0
+  limit = 50
+  print(f"lambda_handler: offset={offset}, limit={limit}")
+
+  s3 = boto3.client("s3")
+  paginator = s3.get_paginator("list_objects_v2")
+  response_objects = []
+
+  for artifact_type in types:
+    prefix = f"artifacts/{artifact_type}"
+
+    if name != "*":
+      # Pulled from upload.py
+      hash_object = hashlib.sha256(name.encode())
+      numeric_hash = int(hash_object.hexdigest(), 16)
+      model_id = numeric_hash % 9999999967
+      key = f"{prefix}/{model_id}/metadata.json"
+      print(f"lambda_handler: looking up key={key}")
+
+      response_objects.append(extract_metadata(s3, s3_bucket, key))
+      continue
+
+    for page in paginator.paginate(Bucket=s3_bucket, Prefix=prefix):
+      if "Contents" in page:
+        for obj in page["Contents"]:
+          key = obj.get("Key")
+          if not key:
+            continue
+          if key.endswith("metadata.json"):
+            response_objects.append(extract_metadata(s3, s3_bucket, key))
+
+  # Apply pagination
+  paginated_objects = response_objects[offset: offset + limit]
+  next_offset = offset + limit if len(response_objects) > offset + limit else None
+
+  headers = {
+    "Content-Type": "application/json",
+    "Access-Control-Allow-Origin": "*",
+  }
+  if next_offset:
+    headers["offset"] = str(next_offset)
+
+  return {"statusCode": 200, "headers": headers, "body": json.dumps(paginated_objects)}
+
+
+def extract_metadata(s3, s3_bucket: str, key: str):
+  """Extract the metadata for a given object based on the filepath
+
+  Returns an object listing the name, id, and type of the artifact for
+  the given key.
+  """
+  try:
+    metadata_obj = s3.get_object(Bucket=s3_bucket, Key=key)
+  except Exception as e:
+    print(f"extract_metadata: failed to get object {key}: {e}")
+    return
+
+  body = metadata_obj.get("Body")
+  raw = body.read() if body is not None else b""
+  # S3 returns bytes; decode if necessary
+  if isinstance(raw, bytes):
+    try:
+      raw = raw.decode("utf-8")
+    except Exception:
+      raw = raw.decode("latin-1", errors="ignore")
+  try:
+    metadata = json.loads(raw)
+  except Exception:
+    # Skip malformed metadata files
+    print(f"extract_metadata: failed to parse metadata for key={key}")
+    return
+
+  ret = {
+    "name": metadata.get("name"),
+    "id": metadata.get("id"),
+    "type": metadata.get("type"),
+  }
+
+  print(f"extract_metadata: Found {ret}")
+  return ret
+
+
+def sanitize_request(event):
+  """Validate and sanitize the incoming request.
+
+  Returns a tuple (sanitized_dict, error_response). On success, error_response is
+  None and sanitized_dict contains the parsed fields. On error, sanitized_dict is
+  an empty dict and error_response contains the HTTP-style error response.
+  """
+  print("sanitize_request: parsing event body")
+  def error(msg):
+    return {}, {
+      "statusCode": 400,
+      "body": json.dumps({"error": msg}),
+    }
+
+  try:
+    body = json.loads(event.get("body", "{}"))
+  except json.JSONDecodeError:
+    print("sanitize_request: invalid JSON body")
+    return error("Invalid JSON body.")
+
+  name = (body.get("name") or "").strip()
+  types = body.get("types", [])
+
+  print(f"sanitize_request: parsed name={name}, types_raw={types}")
+
+  # Validate name
+  if not name:
+    print("sanitize_request: invalid name")
+    return error("Invalid 'name'; must be a non-empty string.")
+
+  # Validate and process types
+  if not isinstance(types, list):
+    return error("Invalid 'types'; must be an array.")
+
+  allowed_types = {"model", "dataset", "code"}
+
+  if types:  # If non-empty, all must be allowed
+    if not all(t in allowed_types for t in types):
+        return error("Invalid type in 'types'.")
+  else:
+    # Default to all types when empty
+    types = list(allowed_types)
+
+  return {"name": name, "types": types}, None

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -1,0 +1,167 @@
+import os
+import json
+import hashlib
+import boto3
+from moto import mock_aws
+from backend.Artifacts.Artifacts import lambda_handler
+
+BUCKET = "test-registry-bucket"
+
+def _generate_artifact_id(name: str) -> str:
+    return str(int(hashlib.sha256(name.encode()).hexdigest(), 16) % 9999999967)
+
+# Helper to upload artifacts
+def _upload_artifacts(s3, artifacts):
+    for atype, name in artifacts.items():
+        artifact_id = _generate_artifact_id(name)
+        key = f"artifacts/{atype}/{artifact_id}/metadata.json"
+        metadata = {"name": name, "id": artifact_id, "type": atype}
+        s3.put_object(Bucket=BUCKET, Key=key, Body=json.dumps(metadata))
+
+@mock_aws
+def test_list_all_artifacts():
+    os.environ["REGISTRY_BUCKET"] = BUCKET
+    s3 = boto3.client("s3", region_name="us-east-2")
+    s3.create_bucket(Bucket=BUCKET, CreateBucketConfiguration={"LocationConstraint": "us-east-2"})
+
+    sample = {
+        "model": "Test Model",
+        "dataset": "Test Dataset",
+        "code": "Test Code",
+    }
+
+    for atype, name in sample.items():
+        artifact_id = _generate_artifact_id(name)
+        key = f"artifacts/{atype}/{artifact_id}/metadata.json"
+        metadata = {"name": name, "id": artifact_id, "type": atype}
+        s3.put_object(Bucket=BUCKET, Key=key, Body=json.dumps(metadata))
+
+    event = {
+        "body": json.dumps({"name": "*", "types": []}),
+        "headers": {},
+    }
+    response = lambda_handler(event, None)
+    assert response["statusCode"] == 200
+
+    body = json.loads(response["body"])
+    returned_names = {item["name"] for item in body}
+    assert returned_names == set(sample.values())
+
+@mock_aws
+def test_filter_by_type_and_name():
+    os.environ["REGISTRY_BUCKET"] = BUCKET
+    s3 = boto3.client("s3", region_name="us-east-2")
+    s3.create_bucket(Bucket=BUCKET, CreateBucketConfiguration={"LocationConstraint": "us-east-2"})
+
+    # Upload only one artifact for dataset
+    artifact_id = _generate_artifact_id("Test Dataset")
+    key = f"artifacts/dataset/{artifact_id}/metadata.json"
+    metadata = {"name": "Test Dataset", "id": artifact_id, "type": "dataset"}
+    s3.put_object(Bucket=BUCKET, Key=key, Body=json.dumps(metadata))
+
+    event = {
+        "body": json.dumps({"name": "Test Dataset", "types": ["dataset"]}),
+        "headers": {},
+    }
+    response = lambda_handler(event, None)
+    assert response["statusCode"] == 200
+
+    body = json.loads(response["body"])
+    assert len(body) == 1
+    assert body[0]["name"] == "Test Dataset"
+    assert body[0]["type"] == "dataset"
+
+
+@mock_aws
+def test_filter_multiple_types():
+    os.environ["REGISTRY_BUCKET"] = BUCKET
+    s3 = boto3.client("s3", region_name="us-east-2")
+    s3.create_bucket(Bucket=BUCKET, CreateBucketConfiguration={"LocationConstraint": "us-east-2"})
+
+    artifacts = {"model": "Model A", "dataset": "Dataset A", "code": "Code A"}
+    _upload_artifacts(s3, artifacts)
+
+    event = {"body": json.dumps({"name": "*", "types": ["model", "dataset"]}), "headers": {}}
+    response = lambda_handler(event, None)
+    body = json.loads(response["body"])
+
+    returned_types = {item["type"] for item in body}
+    assert returned_types == {"model", "dataset"}
+
+@mock_aws
+def test_filter_type_excludes_unrelated():
+    os.environ["REGISTRY_BUCKET"] = BUCKET
+    s3 = boto3.client("s3", region_name="us-east-2")
+    s3.create_bucket(Bucket=BUCKET, CreateBucketConfiguration={"LocationConstraint": "us-east-2"})
+
+    artifacts = {"model": "Model X", "dataset": "Dataset Y", "code": "Code Z"}
+    _upload_artifacts(s3, artifacts)
+
+    event = {"body": json.dumps({"name": "*", "types": ["code"]}), "headers": {}}
+    response = lambda_handler(event, None)
+    body = json.loads(response["body"])
+
+    assert all(item["type"] == "code" for item in body)
+    assert {item["name"] for item in body} == {"Code Z"}
+
+# 6. Valid request but no artifacts found
+@mock_aws
+def test_no_artifacts_found():
+    os.environ["REGISTRY_BUCKET"] = BUCKET
+    s3 = boto3.client("s3", region_name="us-east-2")
+    s3.create_bucket(Bucket=BUCKET, CreateBucketConfiguration={"LocationConstraint": "us-east-2"})
+
+    # Do NOT upload any artifacts
+    event = {"body": json.dumps({"name": "*", "types": ["model", "dataset"]}), "headers": {}}
+    response = lambda_handler(event, None)
+    assert response["statusCode"] == 200
+    body = json.loads(response["body"])
+    assert isinstance(body, list)
+    assert len(body) == 0
+
+# 1. Missing REGISTRY_BUCKET environment variable
+@mock_aws
+def test_missing_env_var():
+    os.environ["REGISTRY_BUCKET"] = ""
+    event = {"body": json.dumps({"name": "*", "types": ["model"]}), "headers": {}}
+    # Do NOT set REGISTRY_BUCKET
+    response = lambda_handler(event, None)
+    assert response["statusCode"] == 500
+    assert "REGISTRY_BUCKET" in response["body"] or "missing" in response["body"].lower()
+    os.environ["REGISTRY_BUCKET"] = BUCKET
+
+# 2. Invalid JSON in request body
+@mock_aws
+def test_invalid_json_body():
+    os.environ["REGISTRY_BUCKET"] = BUCKET
+    event = {"body": "{invalid-json}", "headers": {}}
+    response = lambda_handler(event, None)
+    assert response["statusCode"] == 400
+    assert "Invalid JSON" in response["body"] or "error" in response["body"].lower()
+
+# 3. Invalid name field (empty string)
+@mock_aws
+def test_invalid_name_empty():
+    os.environ["REGISTRY_BUCKET"] = BUCKET
+    event = {"body": json.dumps({"name": "", "types": ["model"]}), "headers": {}}
+    response = lambda_handler(event, None)
+    assert response["statusCode"] == 400
+    assert "name" in response["body"].lower()
+
+# 4. Invalid types field (not a list)
+@mock_aws
+def test_invalid_types_not_list():
+    os.environ["REGISTRY_BUCKET"] = BUCKET
+    event = {"body": json.dumps({"name": "*", "types": "model"}), "headers": {}}
+    response = lambda_handler(event, None)
+    assert response["statusCode"] == 400
+    assert "types" in response["body"].lower()
+
+# 5. Invalid type values
+@mock_aws
+def test_invalid_type_values():
+    os.environ["REGISTRY_BUCKET"] = BUCKET
+    event = {"body": json.dumps({"name": "*", "types": ["invalid_type"]}), "headers": {}}
+    response = lambda_handler(event, None)
+    assert response["statusCode"] == 400
+    assert "invalid" in response["body"].lower()


### PR DESCRIPTION
This returns information reguarding an artifact based on the body parameters of name and types.

Testing includes returning everything, filtering by type, filtering by name, and malformed data.